### PR TITLE
fix DOI prefix handling when fetching paper details

### DIFF
--- a/meta_paper/adapters/_doi_prefix.py
+++ b/meta_paper/adapters/_doi_prefix.py
@@ -1,0 +1,15 @@
+import re
+
+
+class DOIPrefixMixin:
+    __DOI_RE = re.compile(r"\bdoi:\b", re.IGNORECASE | re.S)
+
+    def _prepend_doi(self, doi: str, upper_case: bool = True) -> str:
+        doi = doi.strip()
+        prefix = "DOI:" if upper_case else "doi:"
+        if doi.upper().startswith("DOI:"):
+            return self.__DOI_RE.sub(prefix, doi, 1)
+        return f"{prefix}{doi}"
+
+    def _has_doi_prefix(self, doi: str) -> bool:
+        return bool(self.__DOI_RE.search(doi))

--- a/meta_paper/adapters/_open_citations.py
+++ b/meta_paper/adapters/_open_citations.py
@@ -3,10 +3,11 @@ import re
 import httpx
 
 from meta_paper.adapters._base import PaperDetails, PaperListing, PaperMetadataAdapter
+from meta_paper.adapters._doi_prefix import DOIPrefixMixin
 from meta_paper.search import QueryParameters
 
 
-class OpenCitationsAdapter(PaperMetadataAdapter):
+class OpenCitationsAdapter(DOIPrefixMixin, PaperMetadataAdapter):
     REFERENCES_REST_API = "https://opencitations.net/index/api/v2"
     META_REST_API = "https://w3id.org/oc/meta/api/v1"
     DOI_RE = re.compile(r"\b(doi:[0-9a-z./]+)\b", re.IGNORECASE)
@@ -26,10 +27,7 @@ class OpenCitationsAdapter(PaperMetadataAdapter):
 
     async def details(self, doi: str) -> PaperDetails:
         """Fetch references and citations for a DOI."""
-
-        doi = doi.strip()
-        if not doi.startswith("doi:"):
-            doi = f"doi:{doi}"
+        doi = self._prepend_doi(doi, False)
 
         response = await self.__http.get(
             f"{self.REFERENCES_REST_API}/references/{doi}", headers=self.__headers

--- a/meta_paper/client.py
+++ b/meta_paper/client.py
@@ -18,10 +18,12 @@ from meta_paper.search import QueryParameters
 class PaperMetadataClient:
     def __init__(self, http_client: httpx.AsyncClient | None = None):
         self.__providers: list[PaperMetadataAdapter] = []
-        self.__http = http_client or httpx.AsyncClient(headers={
-            "Accept": "application/json",
-            "Accept-Encoding": "deflate,gzip;q=1.0",
-        })
+        self.__http = http_client or httpx.AsyncClient(
+            headers={
+                "Accept": "application/json",
+                "Accept-Encoding": "deflate,gzip;q=1.0",
+            }
+        )
 
     @property
     def providers(self) -> Sequence[PaperMetadataAdapter]:

--- a/tests/adapters/test_semantic_scholar.py
+++ b/tests/adapters/test_semantic_scholar.py
@@ -339,3 +339,14 @@ async def test_details_calls_api_endpoint_as_expected(
     assert request.url.path == "/graph/v1/paper/DOI:123/456"
     assert request.method == "GET"
     assert request.headers.get("x-api-key") == expected_api_key
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "doi", ["123/456", "doi:123/456", "DOI:123/456", "dOi:123/456"]
+)
+async def test_details_handles_doi_str_variations(sut, request_handler, doi):
+    await sut.details(doi)
+
+    request = request_handler.call_args_list[0].args[0]
+    assert request.url.path == "/graph/v1/paper/DOI:123/456"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,12 +26,18 @@ def semantic_scholar_search_response(request, semantic_scholar_search_result):
 
 @pytest.fixture
 def request_handler(semantic_scholar_search_response):
-    return AsyncMock(name="client_request_handler", return_value=semantic_scholar_search_response)
+    return AsyncMock(
+        name="client_request_handler", return_value=semantic_scholar_search_response
+    )
 
 
 @pytest.fixture
 def metadata_client(http_client, auth_token):
-    return PaperMetadataClient(http_client).use_open_citations(auth_token).use_semantic_scholar(auth_token)
+    return (
+        PaperMetadataClient(http_client)
+        .use_open_citations(auth_token)
+        .use_semantic_scholar(auth_token)
+    )
 
 
 def test_client_init():


### PR DESCRIPTION
Sometimes, users omit adding the required "doi:" prefix to the parameter when calling the `details` method of the client.
The prefix handler adds it. But it didn't use to add it well.
For instance, when the input parameter had a "dOi:" or a "Doi:" prefix (notice the casing), the prefix handler would wrongly prepend a "DOI:" prefix.

This PR makes the prefix handling both more correct and more flexible.