### PR TITLE
Implement batch retrieval of paper references

### DIFF
--- a/meta_paper/adapters/_base.py
+++ b/meta_paper/adapters/_base.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, Iterable
 
 from meta_paper.search import QueryParameters
 
@@ -18,11 +18,16 @@ class PaperDetails:
     authors: list[str]
     abstract: str
     references: list[str]
+    has_pdf: bool = False
+    pdf_url: str | None = None
 
 
 class PaperMetadataAdapter(Protocol):
     async def search(self, query: QueryParameters) -> list[PaperListing]:
         pass
 
-    async def details(self, doi: str) -> PaperDetails:
+    async def get_one(self, doi: str) -> PaperDetails:
+        pass
+
+    async def get_many(self, identifiers: Iterable[str]) -> Iterable[PaperDetails]:
         pass

--- a/meta_paper/adapters/_doi_prefix.py
+++ b/meta_paper/adapters/_doi_prefix.py
@@ -5,7 +5,7 @@ class DOIPrefixMixin:
     __DOI_RE = re.compile(r"\bdoi:\b", re.IGNORECASE | re.S)
 
     def _prepend_doi(self, doi: str, upper_case: bool = True) -> str:
-        doi = doi.strip()
+        doi = str(doi).strip()
         prefix = "DOI:" if upper_case else "doi:"
         if doi.upper().startswith("DOI:"):
             return self.__DOI_RE.sub(prefix, doi, 1)

--- a/meta_paper/adapters/_open_citations.py
+++ b/meta_paper/adapters/_open_citations.py
@@ -1,4 +1,5 @@
 import re
+from typing import Iterable
 
 import httpx
 from tenacity import (
@@ -44,12 +45,11 @@ class OpenCitationsAdapter(DOIPrefixMixin, PaperMetadataAdapter):
         wait=wait_exponential_jitter(max=10),
         stop=stop_after_delay(10),
     )
-    async def details(self, doi: str) -> PaperDetails:
+    async def get_one(self, doi: str | Iterable[str]) -> PaperDetails:
         """Fetch references and citations for a DOI."""
         doi = self._prepend_doi(doi, False)
         if not self.DOI_RE.match(doi):
             raise ValueError(f"{doi} is not a valid DOI")
-
         response = await self.__http.get(
             f"{self.REFERENCES_REST_API}/references/{doi}", headers=self.__headers
         )
@@ -74,3 +74,6 @@ class OpenCitationsAdapter(DOIPrefixMixin, PaperMetadataAdapter):
             abstract="",
             references=refs,
         )
+
+    async def get_many(self, identifiers: Iterable[str]) -> Iterable[PaperDetails]:
+        return []

--- a/meta_paper/adapters/_semantic_scholar.py
+++ b/meta_paper/adapters/_semantic_scholar.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Iterable
 
 import httpx
 from tenacity import (
@@ -18,7 +19,10 @@ def _retry_semantic_scholar(exc: BaseException) -> bool:
 
 
 class SemanticScholarAdapter(DOIPrefixMixin, PaperMetadataAdapter):
-    BASE_URL = "https://api.semanticscholar.org/graph/v1"
+    __BASE_URL = "https://api.semanticscholar.org/graph/v1"
+    __DETAIL_FIELDS = {
+        "fields": "externalIds,title,authors,references.externalIds,abstract,isOpenAccess,openAccessPdf"
+    }
 
     def __init__(self, http_client: httpx.AsyncClient, api_key: str | None = None):
         self.__http = http_client
@@ -34,7 +38,7 @@ class SemanticScholarAdapter(DOIPrefixMixin, PaperMetadataAdapter):
         wait=wait_exponential_jitter(1, 8),
     )
     async def search(self, query: QueryParameters) -> list[PaperListing]:
-        search_endpoint = f"{self.BASE_URL}/paper/search"
+        search_endpoint = f"{self.__BASE_URL}/paper/search"
         query_params = query.semantic_scholar().set(
             "fields", "title,externalIds,authors"
         )
@@ -44,29 +48,35 @@ class SemanticScholarAdapter(DOIPrefixMixin, PaperMetadataAdapter):
         response.raise_for_status()
 
         search_results = response.json().get("data", [])
-        return [
-            PaperListing(
-                doi=paper_info["externalIds"]["DOI"],
-                title=paper_info["title"],
-                authors=author_names,
+        result = []
+        for paper_info in search_results:
+            if not self.__has_valid_doi(paper_info):
+                continue
+            if not paper_info.get("title"):
+                continue
+            if not (author_names := self.__get_author_names(paper_info)):
+                continue
+            result.append(
+                PaperListing(
+                    doi=paper_info["externalIds"]["DOI"],
+                    title=paper_info["title"],
+                    authors=author_names,
+                )
             )
-            for paper_info in search_results
-            if self.__has_valid_doi(paper_info)
-            and paper_info.get("title")
-            and (author_names := self.__get_author_names(paper_info))
-        ]
+        return result
 
     @retry(
         retry=retry_if_exception(_retry_semantic_scholar),
         stop=stop_after_delay(timedelta(seconds=10)),
         wait=wait_exponential_jitter(1, 8),
     )
-    async def details(self, doi: str) -> PaperDetails:
+    async def get_one(self, doi: str) -> PaperDetails:
         doi = self._prepend_doi(doi)
-        paper_details_endpoint = f"{self.BASE_URL}/paper/{doi}"
-        params = {"fields": "title,authors,references.externalIds,abstract"}
+        paper_details_endpoint = f"{self.__BASE_URL}/paper/{doi}"
         response = await self.__http.get(
-            paper_details_endpoint, headers=self.__request_headers, params=params
+            paper_details_endpoint,
+            headers=self.__request_headers,
+            params=self.__DETAIL_FIELDS,
         )
         response.raise_for_status()
 
@@ -79,16 +89,59 @@ class SemanticScholarAdapter(DOIPrefixMixin, PaperMetadataAdapter):
             abstract = ""
 
         return PaperDetails(
-            doi=doi,
+            doi=self.__get_doi(paper_data.get("externalIds")),
             title=title,
             authors=authors,
             abstract=abstract,
-            references=[
-                self._prepend_doi(ref["externalIds"]["DOI"])
-                for ref in paper_data["references"]
-                if self.__has_valid_doi(ref)
-            ],
+            references=self.__get_references(paper_data),
+            has_pdf=paper_data.get("isOpenAccess") or False,
+            pdf_url=self.__get_pdf_url(paper_data),
         )
+
+    @retry(
+        retry=retry_if_exception(_retry_semantic_scholar),
+        stop=stop_after_delay(timedelta(seconds=60)),
+        wait=wait_exponential_jitter(1, 8),
+    )
+    async def get_many(self, identifiers: Iterable[str]) -> Iterable[PaperDetails]:
+        if identifiers:
+            identifiers = list(map(self._prepend_doi, filter(bool, identifiers)))
+        if not identifiers:
+            return []
+
+        response = await self.__http.post(
+            f"{self.__BASE_URL}/paper/batch",
+            headers=self.__request_headers,
+            params=self.__DETAIL_FIELDS,
+            json={"ids": identifiers},
+        )
+        response.raise_for_status()
+
+        paper_list = response.json()
+        result = []
+        for paper_data in paper_list:
+            if not (title := paper_data.get("title")):
+                print("paper title missing")
+                continue
+            if not (authors := self.__get_author_names(paper_data)):
+                print("paper authors missing")
+                continue
+            if not (abstract := paper_data.get("abstract")):
+                abstract = ""
+            doi = self.__get_doi(paper_data.get("externalIds"))
+
+            result.append(
+                PaperDetails(
+                    doi=doi,
+                    title=title,
+                    authors=authors,
+                    abstract=abstract,
+                    references=self.__get_references(paper_data),
+                    has_pdf=paper_data.get("isOpenAccess") or False,
+                    pdf_url=self.__get_pdf_url(paper_data),
+                )
+            )
+        return result
 
     @staticmethod
     def __has_valid_doi(paper_info: dict) -> bool:
@@ -100,9 +153,32 @@ class SemanticScholarAdapter(DOIPrefixMixin, PaperMetadataAdapter):
 
     @staticmethod
     def __get_author_names(author_data: dict) -> list[str]:
-        if not author_data.get("authors"):
+        if author_data is None:
             return []
-        if not any("name" in x and x["name"] for x in author_data["authors"]):
-            return []
+        author_objs = list(filter(bool, author_data.get("authors") or []))
+        authors = list(filter(bool, map(lambda x: x.get("name"), author_objs)))
+        return list(map(str, authors))
 
-        return list(map(str, (author["name"] for author in author_data["authors"])))
+    @staticmethod
+    def __get_pdf_url(paper_data: dict) -> str:
+        if paper_data is None:
+            return ""
+        pdf_info = paper_data.get("openAccessPdf") or {}
+        return pdf_info.get("url") or ""
+
+    def __get_doi(self, external_ids_obj: dict) -> str:
+        if external_ids_obj is None:
+            return ""
+        doi = external_ids_obj.get("DOI") or ""
+        if not doi:
+            return ""
+        return self._prepend_doi(doi)
+
+    def __get_references(self, paper_data: dict) -> list[str]:
+        if paper_data is None:
+            return []
+        ref_objs = list(filter(bool, paper_data.get("references") or []))
+        external_id_objs = list(
+            filter(bool, map(lambda x: x.get("externalIds"), ref_objs))
+        )
+        return list(filter(bool, map(self.__get_doi, external_id_objs)))

--- a/meta_paper/client.py
+++ b/meta_paper/client.py
@@ -1,7 +1,7 @@
 import asyncio
 import itertools
 from collections.abc import Sequence
-from typing import Iterable, Generator
+from typing import Iterable, Generator, Callable
 
 import httpx
 from tenacity import RetryError
@@ -53,38 +53,72 @@ class PaperMetadataClient:
         results = list(itertools.chain.from_iterable(results))
         return list(self.__dedupe_by_doi(results))
 
-    async def details(self, doi: str) -> PaperDetails:
+    async def get_one(self, doi: str) -> PaperDetails:
         """Fetch paper summaries asynchronously from all providers."""
-        tasks = [provider.details(doi) for provider in self.providers]
-        summaries = []
+        tasks = [provider.get_one(doi) for provider in self.providers]
+        paper_data = []
         for coro in asyncio.as_completed(tasks):
             try:
-                summaries.append(await coro)
+                paper_data.append(await coro)
             except RetryError:
                 print(f"retry count exceeded for doi '{doi}'")
             except Exception as exc:
                 print("generic error fetching '%s': %s" % (doi, exc))
 
-        doi = max((summary.doi for summary in summaries), key=len, default="")
-        title = max((summary.title for summary in summaries), key=len, default="")
-        abstract = max((summary.abstract for summary in summaries), key=len, default="")
-        refs = set(
-            itertools.chain.from_iterable(summary.references for summary in summaries)
+        return self.__to_paper_details(paper_data)
+
+    async def get_many(self, identifiers: Iterable[str]) -> Iterable[PaperDetails]:
+        """Fetch paper summaries asynchronously from all providers."""
+        tasks = [provider.get_many(identifiers) for provider in self.providers]
+        paper_data = {}
+        for coro in asyncio.as_completed(tasks):
+            try:
+                provider_papers = await coro
+                for paper in provider_papers:
+                    doi_papers = paper_data.get(paper.doi) or set()
+                    doi_papers.add(paper)
+                    paper_data[paper.doi] = doi_papers
+            except RetryError:
+                print(
+                    f"retry count exceeded for identifiers '{"','".join(identifiers)}'"
+                )
+            except Exception as exc:
+                print(
+                    "generic error fetching '%s': %s" % ("','".join(identifiers), exc)
+                )
+
+        return map(self.__to_paper_details, paper_data.values())
+
+    def __to_paper_details(self, paper_data: Iterable[PaperDetails]) -> PaperDetails:
+        doi = self.__longest_str(paper_data, lambda x: x.doi)
+        title = self.__longest_str(paper_data, lambda x: x.title)
+        abstract = self.__longest_str(paper_data, lambda x: x.abstract)
+        unique_references = set(
+            itertools.chain.from_iterable(x.references for x in paper_data)
         )
-        authors = set(
-            author
-            for author in itertools.chain.from_iterable(
-                summary.authors for summary in summaries
-            )
-            if author
+        unique_author_names = set(
+            a for a in itertools.chain.from_iterable(d.authors for d in paper_data)
         )
+        has_pdf = any(d.has_pdf for d in paper_data)
+        pdf_url = self.__longest_str(paper_data, lambda x: x.pdf_url)
         return PaperDetails(
             doi=doi,
             title=title,
             abstract=abstract,
-            references=list(refs),
-            authors=list(authors),
+            references=list(unique_references),
+            authors=list(unique_author_names),
+            has_pdf=has_pdf,
+            pdf_url=pdf_url,
         )
+
+    @staticmethod
+    def __longest_str(
+        items: Iterable[PaperDetails], attr_selector: Callable[[PaperDetails], str]
+    ) -> str:
+        generate_attr_values = (
+            attr_value for obj in items if (attr_value := attr_selector(obj))
+        )
+        return max(generate_attr_values, key=len, default="")
 
     @staticmethod
     def __dedupe_by_doi(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meta-paper"
-version = "0.2.1"
+version = "0.3.0"
 description = "Python client for fetching scientific paper metadata from multiple sources"
 authors = [
     {name = "Andrei Olar", email = "andrei.olar@gmail.com"}

--- a/tests/adapters/test_open_citations.py
+++ b/tests/adapters/test_open_citations.py
@@ -68,7 +68,7 @@ def test_init_api_token(sut, auth_token, expected):
 async def test_details_makes_expected_call_to_references_api(
     sut, request_handler, doi, auth_token, expected_auth
 ):
-    await sut.details(doi)
+    await sut.get_one(doi)
 
     assert len(request_handler.call_args_list) == 2
     refs_request = request_handler.call_args_list[0].args[0]
@@ -95,7 +95,7 @@ async def test_details_raise_error_on_refs_error_re(
     oc_refs_response.status_code = status_code
 
     with pytest.raises(httpx.HTTPStatusError) as err_wrapper:
-        await sut.details("10.1234/5678")
+        await sut.get_one("10.1234/5678")
 
     assert err_wrapper.value is not None
     assert str(status_code) in str(err_wrapper.value)
@@ -112,7 +112,7 @@ async def test_details_raise_error_on_metadata_endpoint_error(
     oc_metadata_response.status_code = status_code
 
     with pytest.raises(httpx.HTTPStatusError) as err_wrapper:
-        await sut.details("10.1234/5678")
+        await sut.get_one("10.1234/5678")
 
     assert err_wrapper.value is not None
     assert str(status_code) in str(err_wrapper.value)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,7 +24,7 @@ class StubProvider(PaperMetadataAdapter):
         await asyncio.sleep(0.25)
         return self._results
 
-    async def details(self, doi: str) -> PaperDetails:
+    async def get_one(self, doi: str) -> PaperDetails:
         await asyncio.sleep(0.25)
         if isinstance(self._details, Exception):
             raise self._details
@@ -99,7 +99,7 @@ async def test_search_calls_registered_providers(
 
 
 @pytest.mark.asyncio
-async def test_client_returns_longest_doi(http_client):
+async def test_get_one_returns_longest_doi(http_client):
     sut = (
         PaperMetadataClient(http_client)
         .use_custom_provider(
@@ -113,13 +113,13 @@ async def test_client_returns_longest_doi(http_client):
             )
         )
     )
-    actual = await sut.details("10.1234/5678")
+    actual = await sut.get_one("10.1234/5678")
 
     assert actual.doi == "10.1234/56789"
 
 
 @pytest.mark.asyncio
-async def test_client_returns_longest_title(http_client):
+async def test_get_one_returns_longest_title(http_client):
     sut = (
         PaperMetadataClient(http_client)
         .use_custom_provider(
@@ -135,13 +135,13 @@ async def test_client_returns_longest_title(http_client):
             )
         )
     )
-    actual = await sut.details("10.1234/5678")
+    actual = await sut.get_one("10.1234/5678")
 
     assert actual.title == "ti"
 
 
 @pytest.mark.asyncio
-async def test_client_returns_longest_abstract(http_client):
+async def test_get_one_returns_longest_abstract(http_client):
     sut = (
         PaperMetadataClient(http_client)
         .use_custom_provider(
@@ -155,13 +155,13 @@ async def test_client_returns_longest_abstract(http_client):
             )
         )
     )
-    actual = await sut.details("10.1234/5678")
+    actual = await sut.get_one("10.1234/5678")
 
     assert actual.abstract == "a2"
 
 
 @pytest.mark.asyncio
-async def test_client_returns_unique_authors(http_client):
+async def test_get_one_returns_unique_authors(http_client):
     sut = (
         PaperMetadataClient(http_client)
         .use_custom_provider(
@@ -175,13 +175,13 @@ async def test_client_returns_unique_authors(http_client):
             )
         )
     )
-    actual = await sut.details("10.1234/5678")
+    actual = await sut.get_one("10.1234/5678")
 
     assert actual.authors == ["a"]
 
 
 @pytest.mark.asyncio
-async def test_client_returns_unique_refs(http_client):
+async def test_get_one_returns_unique_refs(http_client):
     sut = (
         PaperMetadataClient(http_client)
         .use_custom_provider(
@@ -195,13 +195,13 @@ async def test_client_returns_unique_refs(http_client):
             )
         )
     )
-    actual = await sut.details("10.1234/5678")
+    actual = await sut.get_one("10.1234/5678")
 
     assert actual.references == ["10.1234/5678"]
 
 
 @pytest.mark.asyncio
-async def test_details_returns_data_from_successful_provider(http_client):
+async def test_get_one_returns_data_from_successful_provider(http_client):
     sut = (
         PaperMetadataClient(http_client)
         .use_custom_provider(StubProvider(details=Exception("test error")))
@@ -211,7 +211,7 @@ async def test_details_returns_data_from_successful_provider(http_client):
             )
         )
     )
-    actual = await sut.details("10.1234/5678")
+    actual = await sut.get_one("10.1234/5678")
 
     assert actual.doi == "10.1234/56789"
     assert actual.title == "t"


### PR DESCRIPTION
This currently works only with the Semantic Scholar API because the Open Citations API does not support this in their REST interface. Either a reimplementation using SPARQL or dropping the Open Citations endpoints altogether is required here. 