### PR TITLE
fix processing batch returns containing missing articles

### DIFF
--- a/meta_paper/adapters/_semantic_scholar.py
+++ b/meta_paper/adapters/_semantic_scholar.py
@@ -143,6 +143,8 @@ class SemanticScholarAdapter(DOIPrefixMixin, PaperMetadataAdapter):
                 paper_list = response.json()
 
                 for paper_data in paper_list:
+                    if paper_data is None:
+                        continue
                     if not (title := paper_data.get("title")):
                         self.__logger.debug("paper title missing")
                         continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meta-paper"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python client for fetching scientific paper metadata from multiple sources"
 authors = [
     {name = "Andrei Olar", email = "andrei.olar@gmail.com"}

--- a/tests/adapters/test_semantic_scholar.py
+++ b/tests/adapters/test_semantic_scholar.py
@@ -486,3 +486,21 @@ async def test_get_many_handles_missing_references_as_expected(sut, request_hand
     assert len(result[0].references) == 0
     assert result[1].doi == "DOI:789/123"
     assert len(result[1].references) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "batch_response",
+    [
+        [
+            None,
+            new_detail(externalIds={"DOI": "789/123"}),
+        ],
+    ],
+    indirect=True,
+)
+async def test_get_many_handles_none_returns(sut, request_handler):
+    result = await sut.get_many(["123/456", "789/123"])
+
+    assert len(result) == 1
+    assert result[0].doi == "DOI:789/123"


### PR DESCRIPTION
When the semanticscholar batch paper details API receives identifiers that are missing from the semanticscholar database as input, it will return 'None' values for those identifiers. This patch skips over 'None' values in the response.

Bump version to 0.4.1